### PR TITLE
draft of torch quantization parameter export

### DIFF
--- a/WooJeong/torch_qparam_export_draft/Net_Conv2d.py
+++ b/WooJeong/torch_qparam_export_draft/Net_Conv2d.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+import torch.quantization
+from Net_Conv2d_3 import Net_Conv2d_3 as SubNet
+# torch.quantization is deprecated. Need to use torch.ao.quantization in latest torch, but we assume to use torch 1.7.0
+
+
+class Net_Conv2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.quant = torch.quantization.QuantStub()
+        self.conv1 = nn.Conv2d(2, 4, 2)
+        self.act1 = nn.ReLU()
+        self.conv2 = nn.Conv2d(4, 8, 2)
+        self.act2 = nn.ReLU()
+        self.conv3 = nn.Conv2d(8, 8, 2)
+        self.act3 = nn.ReLU()
+        self.subnet = SubNet()
+        self.dequant = torch.quantization.DeQuantStub()
+
+    def forward(self, x):
+        x = self.quant(x)
+        x = self.conv1(x)
+        x = self.act1(x)
+        x = self.conv2(x)
+        x = self.act2(x)
+        x = self.conv3(x)
+        x = self.act3(x)
+        x = x.reshape(2, 2, 4, -1)
+        x = self.subnet(x)
+        x = self.dequant(x)
+        return x

--- a/WooJeong/torch_qparam_export_draft/Net_Conv2d_3.py
+++ b/WooJeong/torch_qparam_export_draft/Net_Conv2d_3.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn as nn
+import torch.quantization
+# torch.quantization is deprecated. Need to use torch.ao.quantization in latest torch, but we assume to use torch 1.7.0
+
+
+class Net_Conv2d_3(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(2, 4, 1)
+        self.act1 = nn.ReLU()
+        self.conv2 = nn.Conv2d(4, 8, 2)
+        self.act2 = nn.ReLU()
+        self.conv3 = nn.Conv2d(8, 8, 2)
+        self.act3 = nn.ReLU()
+        self.conv4 = nn.Conv2d(8, 16, 2)
+        self.act4 = nn.ReLU()
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.act1(x)
+        x = self.conv2(x)
+        x = self.act2(x)
+        x = self.conv3(x)
+        x = self.act3(x)
+        x = self.conv4(x)
+        x = self.act4(x)
+        return x

--- a/WooJeong/torch_qparam_export_draft/Torch_QParam_Exporter.py
+++ b/WooJeong/torch_qparam_export_draft/Torch_QParam_Exporter.py
@@ -10,7 +10,7 @@ import json
 def permute(tensor):
     dim = len(tensor.shape)
     if dim == 4:  # NCHW to NHWC
-        tensor = tensor.permute(0, 3, 1, 2)
+        tensor = tensor.permute(0, 2, 3, 1)
     return tensor
 
 

--- a/WooJeong/torch_qparam_export_draft/Torch_QParam_Exporter.py
+++ b/WooJeong/torch_qparam_export_draft/Torch_QParam_Exporter.py
@@ -1,0 +1,117 @@
+import os
+import torch
+import torch.nn
+import torch.quantization
+import numpy as np
+import collections
+import json
+
+
+def permute(tensor):
+    dim = len(tensor.shape)
+    if dim == 4:  # NCHW to NHWC
+        tensor = tensor.permute(0, 3, 1, 2)
+    return tensor
+
+
+class TorchQParamExporter:
+    def __save_np(self, data):
+        file_name = str(self.__np_idx) + ".npy"
+        np.save(os.path.join(self.__dir_path, file_name), data)
+        self.__np_idx += 1
+        return file_name
+
+    def __init__(self, quantized_model, json_path, default_dtype=torch.quint8):
+        if quantized_model is None or not isinstance(quantized_model, torch.nn.Module):
+            raise Exception("There is no Pytorch Model")
+        if json_path is None:
+            raise Exception("Please specify save path")
+        self.__default_dtype = default_dtype
+        self.__json_path = json_path
+        idx = json_path.rfind(os.path.sep)
+        if idx == -1:
+            self.__dir_path = ""
+        else:
+            self.__dir_path = json_path[:idx + 1]
+        self.__np_idx = 0
+        self.__data = {}
+        self.__tree = collections.OrderedDict()
+        self.__extract_module(module=quantized_model)
+        self.__qdtype_mapping = {
+            torch.quint8: {'str': "uint8", 'np': np.uint8},
+            torch.qint8: {'str': "int8", 'np': np.int8},
+            torch.qint32: {'str': "int32", 'np': np.int32}
+        }
+        self.save()
+
+    def __extract_module(self, module):
+        tree = self.__tree
+        for name, tensor in module.state_dict().items():
+            layer = name[:name.rfind(".")]
+            if layer in tree:
+                data = tree[layer]
+            else:
+                data = {}
+                tree[layer] = data
+            tensor_name = name[name.rfind(".") + 1:]
+            data[tensor_name] = tensor
+
+    def save(self):
+        tree = self.__tree
+        data = {}
+        if not os.path.exists(self.__dir_path):
+            os.makedirs(self.__dir_path, exist_ok=True)
+
+        for name, layer in tree.items():
+            if "weight" in layer:
+                tensor = permute(layer['weight'])
+                if tensor.is_quantized:
+                    data[name + ".weight"] = self.__from_tensor(tensor=tensor)
+            if "scale" in layer and "zero_point" in layer:
+                # not sure about torch operator's scale and zero_point is for bias or input
+                # let's assume operator's scale and zero_point is used for both bias and input
+                scale = permute(layer['scale']).numpy()
+                zero_point = permute(layer['zero_point']).numpy()
+                data[name] = {
+                    'scale': self.__save_np(scale),
+                    'zerop': self.__save_np(zero_point),
+                    'dtype': self.__qdtype_mapping[self.__default_dtype]['str']
+                }
+
+                if "bias" in layer:
+                    quantized_bias = self.quantize_bias(permute(layer['bias']), scale, zero_point)
+                    data[name + '.bias'] = data[name].copy()
+                    data[name + '.bias']['value'] = self.__save_np(quantized_bias)
+        with open(self.__json_path, 'w') as json_file:
+            json.dump(data, json_file)
+
+    def __from_tensor(self, tensor):
+        if tensor is None:
+            raise Exception('tensor is null')
+        data = {}
+        if tensor.qscheme() in (torch.per_tensor_affine, torch.per_tensor_symmetric):
+            data['scale'] = self.__save_np(np.array(tensor.q_scale()))
+            data['zerop'] = self.__save_np(np.array(tensor.q_zero_point()))
+        elif tensor.qscheme() in (torch.per_channel_affine, torch.per_channel_symmetric, torch.per_channel_affine_float_qparams):
+            data['scale'] = self.__save_np(tensor.q_per_channel_scales().numpy())
+            data['zerop'] = self.__save_np(tensor.q_per_channel_zero_points().numpy())
+            data['quantized_dimension'] = tensor.q_per_channel_axis()
+
+        # https://pytorch.org/docs/stable/quantization.html#quantized-tensor
+        # https://pytorch.org/docs/1.7.0/quantization.html#quantized-tensors
+        # According to documentation, pytorch latest tensor support quint8, qint8, qint32, float16
+        # But we use pytorch 1.7.0 due to onnx-tf, pytorch 1.7.0 do not support float16
+        if tensor.dtype == torch.qint8:
+            data['value'] = self.__save_np(torch.int_repr(tensor).numpy())
+        else:
+            data['value'] = self.__save_np(tensor.numpy())
+        data['dtype'] = self.__qdtype_mapping[tensor.dtype]['str']
+        return data
+
+    def quantize_bias(self, tensor, scale, zero_point, dtype=np.int8):
+        if dtype not in (np.uint8, np.int8, np.int32):
+            raise Exception('Check dtype of bias quantization')
+        bias = tensor.clone().detach().numpy()
+        bias = bias / scale + zero_point
+        return bias
+

--- a/WooJeong/torch_qparam_export_draft/export_main.py
+++ b/WooJeong/torch_qparam_export_draft/export_main.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn as n
+import torch.quantization
+# torch.quantization is deprecated. Need to use torch.ao.quantization in latest torch, but we assume to use torch 1.7.0
+from Net_Conv2d import Net_Conv2d
+import numpy
+import onnx
+import onnx_tf
+import tensorflow as tf
+import os
+from Torch_QParam_Exporter import TorchQParamExporter
+
+dir = "./out/"
+
+if not os.path.exists("out"):
+    os.mkdir(dir);
+
+torch.manual_seed(123456)
+
+input = torch.randn(4, 2, 4, 6)
+
+model = Net_Conv2d()
+torch.save(model, dir + "conv2d_original.pth")
+
+onnx_path = dir + "conv2d_original.onnx"
+torch.onnx.export(model, input, onnx_path, opset_version=9)
+onnx_model = onnx.load(onnx_path)
+onnx.checker.check_model(onnx_model)
+
+inferred_model = onnx.shape_inference.infer_shapes(onnx_model)
+onnx.checker.check_model(inferred_model)
+onnx.save(inferred_model, onnx_path)
+tf_prep = onnx_tf.backend.prepare(inferred_model)
+tf_prep.export_graph(path=dir + "conv2d_original.tf")
+converter = tf.lite.TFLiteConverter.from_saved_model(dir + "conv2d_original.tf")
+converter.allow_custom_ops = True
+converter.experimental_new_converter = True
+converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS]
+tflite_model = converter.convert()
+open(dir + "conv2d_original.tflite", "wb").write(tflite_model)
+
+model.eval()
+model.qconfig = torch.quantization.get_default_qconfig('x86')
+p_model = torch.quantization.prepare(model)
+p_model(input)
+quantized = torch.quantization.convert(p_model)
+quantized(input)
+torch.save(quantized, dir + "conv2d_quantized.pth")
+
+print(quantized)
+exporter = TorchQParamExporter(quantized_model=quantized, json_path="export/Net_Conv2d/qparam.json")


### PR DESCRIPTION
우선 torch quantization model을 받아서 model 내에 존재하는(submodule 포함) operator내에 존재하는 quantization parameter를 추출하는 Sample code 입니다.

torch에서는 bias가 quantization 되지 않고 양자화가 필요한 경우 inference 때 bias를 quantization 하여 사용하는데, operator가 가지고 있는 quantization parameter(scale, zero point)가 bias를 위한 건지 operator의 input을 위한 건지 아직 정확하게 모르겠어서 우선은 두 개 다 해당 값을 이용하게 해두기는 했어요. (찾아보고 나중에 수정해야할 것 같아요...!)